### PR TITLE
Using compile-mode in cljsbuild-mode.

### DIFF
--- a/cljsbuild-mode.el
+++ b/cljsbuild-mode.el
@@ -47,6 +47,7 @@
 ;; 3. Start cljsbuild-mode in the terminal buffer with M-x cljsbuild-mode
 
 (require 'ansi-color)
+(require 'compile)
 
 (defgroup cljsbuild-mode nil
   "A helper mode for running 'lein cljsbuild' within Emacs."
@@ -86,8 +87,31 @@
   (when cljsbuild-verbose
     (apply #'message format-string args)))
 
+(defcustom cljsbuild-compile-command
+  "lein cljsbuild auto"
+  "Default build command to use for `cljsbuild-compile'."
+  :type 'string
+  :group 'cljsbuild-mode)
+
+(defconst cljsbuild-compilation-error-regexp-alist
+  '(("^Caused by: .+{:column \\([0-9]+\\), :line \\([0-9]+\\), :file \"\\(.+\\)\""
+     3 2 1 nil 3)
+    ("^ERROR: .+ error at \\(.+\\) line \\([0-9]+\\) : \\([0-9]+\\)"
+     1 2 3 nil 3)
+    ("^WARNING: .+ at line \\([0-9]+\\) \\(.+\\.cljs\\)"
+     2 1 1 2 2)
+    ("^WARNING: .+ at line \\([0-9]+\\) file:\\(.+\\)"
+     2 1 1 1 2))
+  "Regexps used for matching ClojureScript compile messages.
+See `compilation-error-regexp-alist' for semantics.")
+
+(defvar cljsbuild-compilation-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map compilation-mode-map))
+  "Keymap for `cljsbuild-compilation-mode' buffers.")
+
 (defun cljsbuild-on-buffer-change
-  (beginning end len)
+  (beginning end &optional len)
   (let ((inserted (buffer-substring-no-properties beginning end))
         (buffer-visible (get-buffer-window (buffer-name) 'visible)))
     (cond ((string-match "^Successfully compiled" inserted)
@@ -105,59 +129,49 @@
            (when (and (not buffer-visible) cljsbuild-show-buffer-on-warnings)
              (switch-to-buffer-other-window (buffer-name) t))))))
 
-(defun cljsbuild-init-mode
-  ()
+(defun cljsbuild-init-mode ()
   "Initialize the minor mode and register a change hook on the
 compilation buffer"
   (remove-hook 'after-change-functions 'cljsbuild-on-buffer-change)
   (add-hook 'after-change-functions 'cljsbuild-on-buffer-change nil t))
-
-(defun cljsbuild-insertion-filter (proc string)
-  "When PROC sends STRING, apply ansi color codes and insert into buffer."
-  (with-current-buffer (process-buffer proc)
-    (let ((moving (= (point) (process-mark proc))))
-      (save-excursion
-	(goto-char (process-mark proc))
-	(insert (ansi-color-apply string))
-	(set-marker (process-mark proc) (point)))
-      (when moving
-        (goto-char (process-mark proc))))))
 
 (defun cljsbuild-process-sentinel
   (process event)
   "Display a message when a change to the process occurs."
   (message "Cljsbuild: %s" event))
 
+;; Functions using compile-mode as cljsbuild output:
+(defun cljsbuild-compilation-filter-hook ()
+  "Local `compilation-filter-hook' for `cljsbuild-compilation-mode'."
+  (ansi-color-apply-on-region compilation-filter-start (point-max))
+  (cljsbuild-on-buffer-change compilation-filter-start (point-max)))
+
+(define-compilation-mode cljsbuild-compilation-mode "cljsbuild"
+  "ClojureScript `compilation-mode'."
+  (set (make-local-variable 'compilation-error-regexp-alist)
+       cljsbuild-compilation-error-regexp-alist)
+
+  (add-hook 'compilation-filter-hook
+            'cljsbuild-compilation-filter-hook nil t))
+
+(defun cljsbuild-do-compile (command)
+  (save-some-buffers (not compilation-ask-about-save)
+                     compilation-save-buffers-predicate)
+  (compilation-start command 'cljsbuild-compilation-mode))
+
 ;;;###autoload
-(defun cljsbuild-start (cmd)
-  "Run cljsbuild in a background buffer."
-  (interactive "sCljsbuild command:")
-  (unless (locate-dominating-file default-directory "project.clj")
-    (error "Not inside a leiningen project"))
-  (with-current-buffer (get-buffer-create "*cljsbuild*")
-    (when (get-buffer-process (current-buffer))
-      (error "Lein cljsbuild is already running"))
-    (buffer-disable-undo)
-    (let ((proc (if (string= cmd "")
-                    (start-process "cljsbuild" (current-buffer) "lein" "cljsbuild" "auto")
-                  (apply #'start-process "cljsbuild" (current-buffer) "lein" "cljsbuild" (split-string cmd)))))
-      (set-process-sentinel proc 'cljsbuild-process-sentinel)
-      (cljsbuild-mode)
-      ;; Colorize output
-      (set-process-filter proc 'cljsbuild-insertion-filter)
-      (font-lock-mode)
-      (message "Started cljsbuild."))))
-
-(defun cljsbuild-stop ()
-  "Stop the cljsbuild background process"
-  (interactive)
-  (let ((proc (get-buffer-process "*cljsbuild*")))
-    (if proc
-        (progn (kill-process proc)
-               (message "Stopped cljsbuild.")
-               (kill-buffer "*cljsbuild*"))
-      (error "Lein cljsbuild is not running"))))
-
+(defun cljsbuild-start (command)
+  "Runs cljsbuild."
+  (interactive
+   (list (read-string "cljsbuild command: "
+		      cljsbuild-compile-command
+		      nil
+		      '("lein cljsbuild once" "lein cljsbuild clean"))))
+  (let ((project-dir (locate-dominating-file default-directory "project.clj")))
+    (if project-dir
+	(cd project-dir)
+      (error "Not inside a Leiningen project")))
+  (cljsbuild-do-compile command))
 
 (provide 'cljsbuild-mode)
 


### PR DESCRIPTION
Marking errors and warnings and linking to source.
Reading compilation command from the minibuffer.
Provided most common build commands in minibuffer history.
