### PR TITLE
Redefined "g" key to run cljsbuild-start.

### DIFF
--- a/cljsbuild-mode.el
+++ b/cljsbuild-mode.el
@@ -101,7 +101,9 @@ See `compilation-error-regexp-alist' for semantics.")
 
 (defvar cljsbuild-compilation-mode-map
   (let ((map (make-sparse-keymap)))
-    (set-keymap-parent map compilation-mode-map))
+    (set-keymap-parent map compilation-mode-map)
+    (define-key map (kbd "g") 'cljsbuild-start)
+    map)
   "Keymap for `cljsbuild-compilation-mode' buffers.")
 
 (defun cljsbuild-on-buffer-change


### PR DESCRIPTION
In compilation mode "g" stands for "recompile". Here I've changed it to run "cljsbuild-start", which allows to choose (M-n/p) between predefined commands.
Predefined commands are "lein cljsbuild {auto,clean,once}", so IMHO there's no need to have them under separate keys.
