### PR TITLE
Code comment delineates end of documentation

### DIFF
--- a/cljsbuild-mode.el
+++ b/cljsbuild-mode.el
@@ -39,6 +39,7 @@
 ;;
 ;; M-x cljsbuild-start
 ;;
+;;; Code:
 
 (require 'ansi-color)
 (require 'compile)


### PR DESCRIPTION
Without a Code tag, the package description (shown in package-list-packages) includes the rest of the
file, including the complete source.
